### PR TITLE
feat: add workflow to block direct pushes to main

### DIFF
--- a/.github/workflows/protect-main.yml
+++ b/.github/workflows/protect-main.yml
@@ -1,0 +1,36 @@
+name: Protect main branch
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  block-direct-push:
+    name: Block Direct Push to Main
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Check if push is from a merged PR
+        id: check-pr
+        run: |
+          # Check if this commit is part of a closed/merged PR
+          # If push came from a PR merge, there will be an associated PR
+          pr_response=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[] | select(.merged_at != null) | {number, title, merged_at}' 2>/dev/null)
+          
+          if [ -z "$pr_response" ]; then
+            # No merged PR found for this commit - this is a direct push
+            echo "::error::Direct push to main detected. Commit ${{ github.sha }} is not part of a merged PR."
+            echo "::error::All changes to main must go through a pull request."
+            echo "::error::Please revert this push and submit your changes via PR instead."
+            exit 1
+          fi
+          
+          echo "Commit is part of merged PR:"
+          echo "$pr_response"
+          
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `protect-main.yml` workflow that runs on push to main
- Checks if commit is part of a merged PR - if not, fails the job
- This catches direct pushes that bypass the PR workflow

## Testing
- Workflow should pass when pushed as part of a PR merge
- Workflow should fail if someone does a direct push to main