### PR TITLE
fix: use vars for SUPABASE_PROJECT_REF and filter deployment_status branches

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -78,7 +78,7 @@ jobs:
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
 
       - name: Apply migrations
         run: supabase db push --linked --include-all --yes
@@ -151,7 +151,7 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
-          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          SUPABASE_PROJECT_REF: ${{ vars.SUPABASE_PROJECT_REF }}
 
       - name: Link dev project and apply migrations
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   deployment_status:
+    branches: [main, dev]
   pull_request:
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Changed `secrets.SUPABASE_PROJECT_REF` → `vars.SUPABASE_PROJECT_REF` in migration workflow
  - The project ref is configured as an environment variable, not a secret
  - This fixes the "Cannot find project ref" CI failure
- Added `branches: [main, dev]` filter to `deployment_status` trigger in CI
  - Reduces CI noise from Vercel deployments on feature branches