### PR TITLE
fix: remove leading comment from delete_account_atomic migration

### DIFF
--- a/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
+++ b/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
@@ -1,4 +1,3 @@
--- Add delete_account_atomic RPC function
 CREATE OR REPLACE FUNCTION public.delete_account_atomic(
   p_user_id uuid,
   p_email text,


### PR DESCRIPTION
## Summary
- Remove leading comment from `20260405120000_add_delete_account_atomic_rpc.sql`
- The comment causes Supabase migration to fail with SQL parse error
- This unblocks the CI/CD pipeline migration jobs