### PR TITLE
fix: wrap GRANT/REVOKE in DO block for delete_account_atomic migration

### DIFF
--- a/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
+++ b/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
@@ -83,5 +83,8 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.delete_account_atomic(uuid, text, boolean) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.delete_account_atomic(uuid, text, boolean) TO service_role;
+DO $$
+BEGIN
+  EXECUTE 'REVOKE ALL ON FUNCTION public.delete_account_atomic(uuid, text, boolean) FROM PUBLIC';
+  EXECUTE 'GRANT EXECUTE ON FUNCTION public.delete_account_atomic(uuid, text, boolean) TO service_role';
+END $$;


### PR DESCRIPTION
## Summary
- Wrap GRANT/REVOKE statements in a DO block to prevent 'cannot insert multiple commands into a prepared statement' error
- The Supabase CLI splits on semicolons, treating each statement separately
- This matches the pattern used in other migrations (e.g., 20260326020100_set_permissions_create_submission_routes_atomic.sql)