### PR TITLE
fix: use $function$ delimiter instead of $$ for delete_account_atomic

### DIFF
--- a/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
+++ b/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
@@ -16,7 +16,7 @@ RETURNS TABLE (
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public
-AS $$
+AS $function$
 DECLARE
   v_deleted_profile_count integer := 0;
   v_deleted_route_upload_images_count integer := 0;
@@ -81,7 +81,7 @@ BEGIN
     v_nullified_climbs_count,
     v_deleted_climbs_count;
 END;
-$$;
+$function$;
 
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
- Change function body delimiter from $$ to $function$
- The Supabase CLI splits on semicolons and gets confused when both the
  function body and DO block use $$ as delimiter
- Using $function$ for the function body matches the pattern in other working migrations