### PR TITLE
fix: wrap entire migration in single DO block

### DIFF
--- a/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
+++ b/supabase/migrations/20260405120000_add_delete_account_atomic_rpc.sql
@@ -1,3 +1,6 @@
+DO $migration$
+BEGIN
+  EXECUTE $fn$
 CREATE OR REPLACE FUNCTION public.delete_account_atomic(
   p_user_id uuid,
   p_email text,
@@ -81,10 +84,9 @@ BEGIN
     v_nullified_climbs_count,
     v_deleted_climbs_count;
 END;
-$function$;
+$function$
+$fn$;
 
-DO $$
-BEGIN
   EXECUTE 'REVOKE ALL ON FUNCTION public.delete_account_atomic(uuid, text, boolean) FROM PUBLIC';
   EXECUTE 'GRANT EXECUTE ON FUNCTION public.delete_account_atomic(uuid, text, boolean) TO service_role';
-END $$;
+END $migration$;


### PR DESCRIPTION
## Summary\n- Wrap CREATE FUNCTION and GRANT/REVOKE in a single DO block with EXECUTE\n- The Supabase CLI splits on semicolons at the top level, causing 'cannot insert multiple commands into a prepared statement'\n- This ensures only one top-level statement per migration file