### PR TITLE
fix: disable triggers during synced_at backfill

### DIFF
--- a/supabase/migrations/20260407000001_harden_crags_places_sync_triggers.sql
+++ b/supabase/migrations/20260407000001_harden_crags_places_sync_triggers.sql
@@ -142,8 +142,13 @@ ALTER TABLE public.crags ADD COLUMN IF NOT EXISTS synced_at TIMESTAMPTZ;
 ALTER TABLE public.places ADD COLUMN IF NOT EXISTS synced_at TIMESTAMPTZ;
 
 -- Step 3: Initialize synced_at to updated_at for existing rows
+-- Disable triggers to prevent infinite loops during backfill
+ALTER TABLE public.crags DISABLE TRIGGER ALL;
+ALTER TABLE public.places DISABLE TRIGGER ALL;
 UPDATE public.crags SET synced_at = COALESCE(updated_at, NOW()) WHERE synced_at IS NULL;
 UPDATE public.places SET synced_at = COALESCE(updated_at, NOW()) WHERE synced_at IS NULL;
+ALTER TABLE public.crags ENABLE TRIGGER ALL;
+ALTER TABLE public.places ENABLE TRIGGER ALL;
 
 -- Step 4: Recreate final versions with synced_at guard
 


### PR DESCRIPTION
## Summary\n- Disable triggers on crags and places tables during synced_at column backfill\n- The UPDATE on places fires sync_place_to_crag trigger which writes to crags with a region_id that may not exist in regions table\n- Disabling triggers during backfill prevents FK violation