### PR TITLE
fix: drop default before casting status column to image_status enum

### DIFF
--- a/supabase/migrations/20260408000000_add_enum_types.sql
+++ b/supabase/migrations/20260408000000_add_enum_types.sql
@@ -57,7 +57,9 @@ CREATE TYPE crag_type AS ENUM ('crag', 'boulder', 'sport', 'trad', 'mixed');
 
 -- Alter tables to use enum types
 -- Images
+ALTER TABLE images ALTER COLUMN status DROP DEFAULT;
 ALTER TABLE images ALTER COLUMN status TYPE image_status USING status::image_status;
+ALTER TABLE images ALTER COLUMN status SET DEFAULT 'pending'::image_status;
 ALTER TABLE images ALTER COLUMN visibility TYPE image_visibility USING visibility::image_visibility;
 ALTER TABLE images ALTER COLUMN processing_status TYPE image_processing_status USING processing_status::image_processing_status;
 ALTER TABLE images ALTER COLUMN moderation_status TYPE image_moderation_status USING moderation_status::image_moderation_status;


### PR DESCRIPTION
## Summary
- Drop default before casting status column to image_status enum
- PostgreSQL cannot automatically cast a text default to an enum type
- Drop the default, change the column type, then restore the default as an enum value